### PR TITLE
Easy access to default config

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -3,6 +3,7 @@ package broker
 import (
 	"log"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -62,6 +63,55 @@ func TestBroker(t *testing.T) {
 	// Test double shutdowns
 	b.Shutdown()
 	b.Shutdown()
+}
+
+func TestUnsubscribe(t *testing.T) {
+	b := New(Config{Logger: log.Printf})
+	defer b.Shutdown()
+	sub, err := b.Subscribe("/foo")
+	assert.Nil(t, err)
+	assert.NotNil(t, sub)
+	doneCh := make(chan struct{})
+
+	go func() {
+		select {
+		case <-doneCh:
+			return
+		case <-sub.Messages():
+			assert.Fail(t, "should not receive any messages")
+		}
+	}()
+	sub.Messages()
+	err = sub.Cancel()
+	assert.Nil(t, err)
+	err = b.Publish("/foo", "should not be received", 0)
+	assert.Nil(t, err)
+	doneCh <- struct{}{} // clean up go routine
+}
+
+func TestPublishTimeout(t *testing.T) {
+	b := New(Config{Logger: log.Printf, DeliveryTimeout: time.Nanosecond})
+	defer b.Shutdown()
+	sub, err := b.Subscribe("/foo")
+	assert.Nil(t, err)
+	waitCh := make(chan struct{})
+	go func() {
+		<-waitCh // blocking message delivery
+		select {
+		case <-waitCh:
+			return
+		case <-sub.Messages():
+			assert.Fail(t, "should not receive any messages")
+		}
+
+	}()
+	err = b.Publish("/foo", "payload", 0)
+	assert.Nil(t, err)
+	time.Sleep(time.Millisecond * 10) // arbitrary sleep to make sure message the goroutine will block
+	waitCh <- struct{}{}              // release message delivery
+	time.Sleep(time.Millisecond * 10) // sleep and make sure the message doesn't arrive
+	assert.Equal(t, uint64(1), atomic.LoadUint64(&b.droppedCount))
+	close(waitCh)
 }
 
 func TestDoubleMessages(t *testing.T) {

--- a/broker_test.go
+++ b/broker_test.go
@@ -66,7 +66,7 @@ func TestBroker(t *testing.T) {
 }
 
 func TestUnsubscribe(t *testing.T) {
-	b := New(Config{Logger: log.Printf})
+	b := New(Default())
 	defer b.Shutdown()
 	sub, err := b.Subscribe("/foo")
 	assert.Nil(t, err)


### PR DESCRIPTION
I made a Default() which will make it somewhat easier to initlize with the default config without having to think too much.

Also, I made some adjustments to the code so it can operate without timeouts. Mostly to help me find potential issues in applications that use package. The zero config is now valid, but not suited for produciton, as it'll block a lot.

This might be considered a breaking change. The zero configuration is now a valid one, where as before it would be silently changed to use the defaults. 🤷🏻 

Expanded test coverage a bit. Feel free to discard this or only keep parts of it. 